### PR TITLE
Feat plugin create

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ You'll love it.
 Templates can be quickly downloaded using the `plugin create` command directly.
 
 By default, the template is installed in the current working directory and named `my_plugin`.
-> Note: This usage requires the `unzip` command on the user's system, and is not supported for Windows at this time.
+> If you are a Windows user, you can use a package manager (e.g. winget, Chocolate) to install `unzip` and then use
 
 ```bash
 $ tkeel plugin create 

--- a/README.md
+++ b/README.md
@@ -138,3 +138,93 @@ echo-demo  keel-system  False    Running   ACTIVE        1         0.0.1    2m  
 $ tkeel plugin delete echo-demo
 ✅  Success! Plugin<echo-demo> has been deleted from tKeel Platform . To verify, run `tkeel plugin list -k' in your terminal.
 ```
+
+### Quickstart to plugin development
+
+We've designed the [Plugin Development Template](https://github.com/tkeel-io/tkeel-template-go) to organise your code
+directly based on this template, and we've helped you to sort out the code hierarchy and provide tools for building APIs
+quickly.
+
+You'll love it.
+
+Templates can be quickly downloaded using the `plugin create` command directly.
+
+By default, the template is installed in the current working directory and named `my_plugin`.
+
+```bash
+$ tkeel plugin create 
+ℹ️  Downloading template...
+ℹ️  Unpacking template...
+/usr/bin/unzip -o /tmp/template.zip
+Archive:  /tmp/template.zip
+59700ef3ee2bbe545f9a4c4c84488c8feacaab6b
+   creating: tkeel-template-go-main/
+  inflating: tkeel-template-go-main/.gitignore
+  inflating: tkeel-template-go-main/Dockerfile
+  inflating: tkeel-template-go-main/LICENSE
+  inflating: tkeel-template-go-main/Makefile
+ extracting: tkeel-template-go-main/README.md
+   creating: tkeel-template-go-main/api/
+   creating: tkeel-template-go-main/api/helloworld/
+   creating: tkeel-template-go-main/api/helloworld/v1/
+  inflating: tkeel-template-go-main/api/helloworld/v1/greeter.pb.go
+  inflating: tkeel-template-go-main/api/helloworld/v1/greeter.proto
+  inflating: tkeel-template-go-main/api/helloworld/v1/greeter_grpc.pb.go
+  inflating: tkeel-template-go-main/api/helloworld/v1/greeter_http.pb.go
+   creating: tkeel-template-go-main/api/openapi/
+   creating: tkeel-template-go-main/api/openapi/v1/
+  inflating: tkeel-template-go-main/api/openapi/v1/openapi.pb.go
+  inflating: tkeel-template-go-main/api/openapi/v1/openapi.proto
+  inflating: tkeel-template-go-main/api/openapi/v1/server.pb.go
+  inflating: tkeel-template-go-main/api/openapi/v1/server.proto
+  inflating: tkeel-template-go-main/api/openapi/v1/server_grpc.pb.go
+  inflating: tkeel-template-go-main/api/openapi/v1/server_http.pb.go
+   creating: tkeel-template-go-main/cmd/
+   creating: tkeel-template-go-main/cmd/hello/
+  inflating: tkeel-template-go-main/cmd/hello/main.go
+  inflating: tkeel-template-go-main/go.mod
+  inflating: tkeel-template-go-main/go.sum
+   creating: tkeel-template-go-main/pkg/
+   creating: tkeel-template-go-main/pkg/server/
+  inflating: tkeel-template-go-main/pkg/server/grpc.go
+  inflating: tkeel-template-go-main/pkg/server/http.go
+   creating: tkeel-template-go-main/pkg/service/
+ extracting: tkeel-template-go-main/pkg/service/README.md
+  inflating: tkeel-template-go-main/pkg/service/greeter.go
+  inflating: tkeel-template-go-main/pkg/service/openapi.go
+   creating: tkeel-template-go-main/pkg/util/
+  inflating: tkeel-template-go-main/pkg/util/util.go
+   creating: tkeel-template-go-main/third_party/
+ extracting: tkeel-template-go-main/third_party/README.md
+   creating: tkeel-template-go-main/third_party/google/
+   creating: tkeel-template-go-main/third_party/google/api/
+  inflating: tkeel-template-go-main/third_party/google/api/annotations.proto
+  inflating: tkeel-template-go-main/third_party/google/api/http.proto
+  inflating: tkeel-template-go-main/third_party/google/api/httpbody.proto
+   creating: tkeel-template-go-main/third_party/google/protobuf/
+  inflating: tkeel-template-go-main/third_party/google/protobuf/descriptor.proto
+  inflating: tkeel-template-go-main/third_party/google/protobuf/empty.proto
+   creating: tkeel-template-go-main/third_party/protoc-gen-openapiv2/
+   creating: tkeel-template-go-main/third_party/protoc-gen-openapiv2/options/
+  inflating: tkeel-template-go-main/third_party/protoc-gen-openapiv2/options/annotations.proto
+  inflating: tkeel-template-go-main/third_party/protoc-gen-openapiv2/options/openapiv2.proto
+   creating: tkeel-template-go-main/third_party/validate/
+  inflating: tkeel-template-go-main/third_party/validate/README.md
+  inflating: tkeel-template-go-main/third_party/validate/validate.proto
+✅  Success!! Plugin template created.
+```
+
+You can add the name of the directory you want to create after the create command, or you can install the template as a
+git with the `-git` flag.
+
+```bash
+$ tkeel plugin create --git my_plugin
+Cloning into 'my_plugin'...
+remote: Enumerating objects: 95, done.
+remote: Counting objects: 100% (95/95), done.
+remote: Compressing objects: 100% (56/56), done.
+remote: Total 95 (delta 22), reused 87 (delta 20), pack-reused 0
+Receiving objects: 100% (95/95), 63.05 KiB | 15.76 MiB/s, done.
+Resolving deltas: 100% (22/22), done.
+✅  Success!! Plugin template created.
+```

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ You'll love it.
 Templates can be quickly downloaded using the `plugin create` command directly.
 
 By default, the template is installed in the current working directory and named `my_plugin`.
+> Note: This usage requires the `unzip` command on the user's system, and is not supported for Windows at this time.
 
 ```bash
 $ tkeel plugin create 
@@ -216,6 +217,7 @@ Archive:  /tmp/template.zip
 
 You can add the name of the directory you want to create after the create command, or you can install the template as a
 git with the `-git` flag.
+> Note: This usage requires the user to have the `git` command on their system
 
 ```bash
 $ tkeel plugin create --git my_plugin

--- a/README.md
+++ b/README.md
@@ -150,7 +150,10 @@ You'll love it.
 Templates can be quickly downloaded using the `plugin create` command directly.
 
 By default, the template is installed in the current working directory and named `my_plugin`.
-> If you are a Windows user, you can use a package manager (e.g. winget, Chocolate) to install `unzip` and then use
+
+> Note: We have used some of the tools that are commonly installed by default on the system.
+
+> The program uses the `unzip` command but uses the `powershell` command on *Windows* OS, so make sure you have these tools on your system when you have unzip problem.
 
 ```bash
 $ tkeel plugin create 

--- a/README_zh.md
+++ b/README_zh.md
@@ -146,7 +146,8 @@ $ tkeel plugin delete echo-demo
 我们设计一套 [插件开发模板](https://github.com/tkeel-io/tkeel-template-go) 您可以直接基于这个模板组织您的代码，我们帮助您梳理了代码层级关系，并提供了快速构建 API
 的工具，您应该会爱不释手的。
 
-直接使用 `plugin create` 命令可以快速下载这套我们提供的模板：
+直接使用 `plugin create` 命令可以快速下载这套我们提供的模板。 默认将模板安装至当前工作目录下，并命名为 `my_plugin`。
+> 注意：该用法需要用户系统中有 `unzip` 命令，暂时不支持 Windows 使用该用法
 
 ```bash
 $ tkeel plugin create 
@@ -211,9 +212,8 @@ Archive:  /tmp/template.zip
 ✅  Success!! Plugin template created.
 ```
 
-默认将模板安装至当前工作目录下，并命名为 `my_plugin`
-
 您可以在创建命令后面添加您想要创建的目录名，也可以通过 `--git` 标志使用 git 的方式安装该模板。
+> 注意：该用法需要用户的系统中有 `git` 命令
 
 ```bash
 $ tkeel plugin create --git my_plugin

--- a/README_zh.md
+++ b/README_zh.md
@@ -140,3 +140,89 @@ echo-demo  keel-system  False    Running   ACTIVE        1         0.0.1    2m  
 $ tkeel plugin delete echo-demo
 ✅  Success! Plugin<echo-demo> has been deleted from tKeel Platform . To verify, run `tkeel plugin list -k' in your terminal.
 ```
+
+### 快速开启插件开发之旅
+
+我们设计一套 [插件开发模板](https://github.com/tkeel-io/tkeel-template-go) 您可以直接基于这个模板组织您的代码，我们帮助您梳理了代码层级关系，并提供了快速构建 API
+的工具，您应该会爱不释手的。
+
+直接使用 `plugin create` 命令可以快速下载这套我们提供的模板：
+
+```bash
+$ tkeel plugin create 
+ℹ️  Downloading template...
+ℹ️  Unpacking template...
+/usr/bin/unzip -o /tmp/template.zip
+Archive:  /tmp/template.zip
+59700ef3ee2bbe545f9a4c4c84488c8feacaab6b
+   creating: tkeel-template-go-main/
+  inflating: tkeel-template-go-main/.gitignore
+  inflating: tkeel-template-go-main/Dockerfile
+  inflating: tkeel-template-go-main/LICENSE
+  inflating: tkeel-template-go-main/Makefile
+ extracting: tkeel-template-go-main/README.md
+   creating: tkeel-template-go-main/api/
+   creating: tkeel-template-go-main/api/helloworld/
+   creating: tkeel-template-go-main/api/helloworld/v1/
+  inflating: tkeel-template-go-main/api/helloworld/v1/greeter.pb.go
+  inflating: tkeel-template-go-main/api/helloworld/v1/greeter.proto
+  inflating: tkeel-template-go-main/api/helloworld/v1/greeter_grpc.pb.go
+  inflating: tkeel-template-go-main/api/helloworld/v1/greeter_http.pb.go
+   creating: tkeel-template-go-main/api/openapi/
+   creating: tkeel-template-go-main/api/openapi/v1/
+  inflating: tkeel-template-go-main/api/openapi/v1/openapi.pb.go
+  inflating: tkeel-template-go-main/api/openapi/v1/openapi.proto
+  inflating: tkeel-template-go-main/api/openapi/v1/server.pb.go
+  inflating: tkeel-template-go-main/api/openapi/v1/server.proto
+  inflating: tkeel-template-go-main/api/openapi/v1/server_grpc.pb.go
+  inflating: tkeel-template-go-main/api/openapi/v1/server_http.pb.go
+   creating: tkeel-template-go-main/cmd/
+   creating: tkeel-template-go-main/cmd/hello/
+  inflating: tkeel-template-go-main/cmd/hello/main.go
+  inflating: tkeel-template-go-main/go.mod
+  inflating: tkeel-template-go-main/go.sum
+   creating: tkeel-template-go-main/pkg/
+   creating: tkeel-template-go-main/pkg/server/
+  inflating: tkeel-template-go-main/pkg/server/grpc.go
+  inflating: tkeel-template-go-main/pkg/server/http.go
+   creating: tkeel-template-go-main/pkg/service/
+ extracting: tkeel-template-go-main/pkg/service/README.md
+  inflating: tkeel-template-go-main/pkg/service/greeter.go
+  inflating: tkeel-template-go-main/pkg/service/openapi.go
+   creating: tkeel-template-go-main/pkg/util/
+  inflating: tkeel-template-go-main/pkg/util/util.go
+   creating: tkeel-template-go-main/third_party/
+ extracting: tkeel-template-go-main/third_party/README.md
+   creating: tkeel-template-go-main/third_party/google/
+   creating: tkeel-template-go-main/third_party/google/api/
+  inflating: tkeel-template-go-main/third_party/google/api/annotations.proto
+  inflating: tkeel-template-go-main/third_party/google/api/http.proto
+  inflating: tkeel-template-go-main/third_party/google/api/httpbody.proto
+   creating: tkeel-template-go-main/third_party/google/protobuf/
+  inflating: tkeel-template-go-main/third_party/google/protobuf/descriptor.proto
+  inflating: tkeel-template-go-main/third_party/google/protobuf/empty.proto
+   creating: tkeel-template-go-main/third_party/protoc-gen-openapiv2/
+   creating: tkeel-template-go-main/third_party/protoc-gen-openapiv2/options/
+  inflating: tkeel-template-go-main/third_party/protoc-gen-openapiv2/options/annotations.proto
+  inflating: tkeel-template-go-main/third_party/protoc-gen-openapiv2/options/openapiv2.proto
+   creating: tkeel-template-go-main/third_party/validate/
+  inflating: tkeel-template-go-main/third_party/validate/README.md
+  inflating: tkeel-template-go-main/third_party/validate/validate.proto
+✅  Success!! Plugin template created.
+```
+
+默认将模板安装至当前工作目录下，并命名为 `my_plugin`
+
+您可以在创建命令后面添加您想要创建的目录名，也可以通过 `--git` 标志使用 git 的方式安装该模板。
+
+```bash
+$ tkeel plugin create --git my_plugin
+Cloning into 'my_plugin'...
+remote: Enumerating objects: 95, done.
+remote: Counting objects: 100% (95/95), done.
+remote: Compressing objects: 100% (56/56), done.
+remote: Total 95 (delta 22), reused 87 (delta 20), pack-reused 0
+Receiving objects: 100% (95/95), 63.05 KiB | 15.76 MiB/s, done.
+Resolving deltas: 100% (22/22), done.
+✅  Success!! Plugin template created.
+```

--- a/README_zh.md
+++ b/README_zh.md
@@ -147,7 +147,7 @@ $ tkeel plugin delete echo-demo
 的工具，您应该会爱不释手的。
 
 直接使用 `plugin create` 命令可以快速下载这套我们提供的模板。 默认将模板安装至当前工作目录下，并命名为 `my_plugin`。
-> 注意：该用法需要用户系统中有 `unzip` 命令，暂时不支持 Windows 使用该用法
+> 注意：该用法需要用户系统中有 `unzip` 命令，如果你是 Windows 用户，你可以使用包管理器（比如说 winget, Chocolate）安装 `unzip` 然后使用
 
 ```bash
 $ tkeel plugin create 

--- a/README_zh.md
+++ b/README_zh.md
@@ -147,7 +147,10 @@ $ tkeel plugin delete echo-demo
 的工具，您应该会爱不释手的。
 
 直接使用 `plugin create` 命令可以快速下载这套我们提供的模板。 默认将模板安装至当前工作目录下，并命名为 `my_plugin`。
-> 注意：该用法需要用户系统中有 `unzip` 命令，如果你是 Windows 用户，你可以使用包管理器（比如说 winget, Chocolate）安装 `unzip` 然后使用
+
+> 注意：我们使用了一些系统中常用默认安装的工具。
+
+> 程序使用了系统中的 `unzip` 命令，如果你是 *Windows* 用户，那么使用到了 `powershall` 所以如果出现了部分解压问题，请确保已安装这些工具。
 
 ```bash
 $ tkeel plugin create 

--- a/cmd/plugin/create.go
+++ b/cmd/plugin/create.go
@@ -6,7 +6,6 @@
 package plugin
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -53,7 +52,6 @@ tkeel plugin create plugin_name
 			gitCloneCMD := exec.Command("git", "clone", githubRepoURL, name)
 			gitCloneCMD.Stdout = os.Stdout
 			gitCloneCMD.Stderr = os.Stdout
-			fmt.Println(gitCloneCMD.String())
 			if err = gitCloneCMD.Run(); err != nil {
 				print.FailureStatusEvent(os.Stdout, "Git clone err:"+err.Error())
 				return
@@ -78,7 +76,6 @@ tkeel plugin create plugin_name
 		unzipcmd := exec.Command("unzip", "-o", tmpDest)
 		unzipcmd.Stderr = os.Stdout
 		unzipcmd.Stdout = os.Stdout
-		fmt.Println(unzipcmd.String())
 		if err := unzipcmd.Run(); err != nil {
 			print.FailureStatusEvent(os.Stdout, "Unzip err:"+err.Error())
 			return

--- a/cmd/plugin/create.go
+++ b/cmd/plugin/create.go
@@ -15,10 +15,6 @@ import (
 	"github.com/tkeel-io/cli/pkg/print"
 )
 
-var (
-	_gitMode bool
-)
-
 const (
 	zipDownloadURL = "https://github.com/tkeel-io/tkeel-template-go/archive/refs/heads/main.zip"
 	githubRepoURL  = "https://github.com/tkeel-io/tkeel-template-go.git"
@@ -28,8 +24,13 @@ const (
 	gitConfigDir            = ".git"
 )
 
+var (
+	_gitMode = false
+	_tempDir = "/tmp"
+)
+
 var Create = &cobra.Command{
-	Use:   "create",
+	Use:   "create [dir]",
 	Short: "Create a plugin in quickstart template.",
 	Example: `
 # Create a plugin in quickstart template.
@@ -65,7 +66,7 @@ tkeel plugin create plugin_name
 
 		print.InfoStatusEvent(os.Stdout, "Downloading template...")
 
-		tmpDest := path.Join("/tmp", downloadedZipFilename)
+		tmpDest := path.Join(_tempDir, downloadedZipFilename)
 		err = downloadutil.Download(tmpDest, zipDownloadURL)
 		if err != nil {
 			print.FailureStatusEvent(os.Stdout, "Template download err:"+err.Error())
@@ -92,6 +93,6 @@ tkeel plugin create plugin_name
 
 func init() {
 	Create.Flags().BoolP("help", "h", false, "Print this help message")
-	Create.Flags().BoolVarP(&_gitMode, "git", "", false, "use github")
+	Create.Flags().BoolVarP(&_gitMode, "git", "", false, "use git to download this template")
 	PluginCmd.AddCommand(Create)
 }

--- a/cmd/plugin/create.go
+++ b/cmd/plugin/create.go
@@ -59,7 +59,7 @@ tkeel plugin create plugin_name
 			if err = os.RemoveAll(path.Join(targetDir, gitConfigDir)); err != nil {
 				print.FailureStatusEvent(os.Stdout, "Remove .git form template err:"+err.Error())
 			}
-			print.SuccessStatusEvent(os.Stdout, "Success!! Plugin template created.")
+			print.SuccessStatusEvent(os.Stdout, "Success!! Plugin template is created.")
 			return
 		}
 
@@ -86,7 +86,7 @@ tkeel plugin create plugin_name
 			return
 		}
 
-		print.SuccessStatusEvent(os.Stdout, "Success!! Plugin template created.")
+		print.SuccessStatusEvent(os.Stdout, "Success!! Plugin template is created.")
 	},
 }
 

--- a/cmd/plugin/create.go
+++ b/cmd/plugin/create.go
@@ -38,7 +38,7 @@ tkeel plugin create
 tkeel plugin create plugin_name
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		name := "app_plugin"
+		name := "my_plugin"
 		if len(args) != 0 {
 			name = args[0]
 		}

--- a/cmd/plugin/create.go
+++ b/cmd/plugin/create.go
@@ -17,6 +17,9 @@ import (
 )
 
 const (
+	windowsOS  = "windows"
+	windowsTmp = "C:\\WINDOWS\\TEMP"
+
 	zipDownloadURL = "https://github.com/tkeel-io/tkeel-template-go/archive/refs/heads/main.zip"
 	githubRepoURL  = "https://github.com/tkeel-io/tkeel-template-go.git"
 
@@ -65,10 +68,12 @@ tkeel plugin create plugin_name
 			return
 		}
 
-		print.InfoStatusEvent(os.Stdout, "Downloading template...")
-		if runtime.GOOS == "windows" {
-			_tempDir = "C:\\WINDOWS\\TEMP"
+		if runtime.GOOS == windowsOS {
+			_tempDir = windowsTmp
 		}
+
+		print.InfoStatusEvent(os.Stdout, "Downloading template...")
+
 		tmpDest := path.Join(_tempDir, downloadedZipFilename)
 		err = downloadutil.Download(tmpDest, zipDownloadURL)
 		if err != nil {
@@ -76,8 +81,18 @@ tkeel plugin create plugin_name
 			return
 		}
 
+		var (
+			unzip     = "unzip"
+			unzipArgs = []string{"-o", tmpDest}
+		)
+
+		if runtime.GOOS == windowsOS {
+			unzip = "Expand-Archive"
+			unzipArgs = []string{"-Path", "'" + tmpDest + "'", "-DestinationsPath", "'" + wd + "'"}
+		}
+
 		print.InfoStatusEvent(os.Stdout, "Unpacking template...")
-		unzipcmd := exec.Command("unzip", "-o", tmpDest)
+		unzipcmd := exec.Command(unzip, unzipArgs...)
 		unzipcmd.Stderr = os.Stdout
 		unzipcmd.Stdout = os.Stdout
 		if err := unzipcmd.Run(); err != nil {

--- a/cmd/plugin/create.go
+++ b/cmd/plugin/create.go
@@ -1,0 +1,100 @@
+// ------------------------------------------------------------
+// Copyright 2021 The tKeel Contributors.
+// Licensed under the Apache License.
+// ------------------------------------------------------------
+
+package plugin
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+
+	"github.com/spf13/cobra"
+	"github.com/tkeel-io/cli/downloadutil"
+	"github.com/tkeel-io/cli/pkg/print"
+)
+
+var (
+	_gitMode bool
+)
+
+const (
+	zipDownloadURL = "https://github.com/tkeel-io/tkeel-template-go/archive/refs/heads/main.zip"
+	githubRepoURL  = "https://github.com/tkeel-io/tkeel-template-go.git"
+
+	downloadedZipFilename   = "template.zip"
+	defaultUnzippedFilename = "tkeel-template-go-main"
+	gitConfigDir            = ".git"
+)
+
+var Create = &cobra.Command{
+	Use:   "create",
+	Short: "Create a plugin in quickstart template.",
+	Example: `
+# Create a plugin in quickstart template.
+tkeel plugin create 
+tkeel plugin create plugin_name
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		name := "app_plugin"
+		if len(args) != 0 {
+			name = args[0]
+		}
+
+		wd, err := os.Getwd()
+		if err != nil {
+			print.FailureStatusEvent(os.Stdout, err.Error())
+		}
+		targetDir := path.Join(wd, name)
+
+		if _gitMode {
+			gitCloneCMD := exec.Command("git", "clone", githubRepoURL, name)
+			gitCloneCMD.Stdout = os.Stdout
+			gitCloneCMD.Stderr = os.Stdout
+			fmt.Println(gitCloneCMD.String())
+			if err = gitCloneCMD.Run(); err != nil {
+				print.FailureStatusEvent(os.Stdout, "Git clone err:"+err.Error())
+				return
+			}
+			if err = os.RemoveAll(path.Join(targetDir, gitConfigDir)); err != nil {
+				print.FailureStatusEvent(os.Stdout, "Remove .git form template err:"+err.Error())
+			}
+			print.SuccessStatusEvent(os.Stdout, "Success!! Plugin template created.")
+			return
+		}
+
+		print.InfoStatusEvent(os.Stdout, "Downloading template...")
+
+		tmpDest := path.Join("/tmp", downloadedZipFilename)
+		err = downloadutil.Download(tmpDest, zipDownloadURL)
+		if err != nil {
+			print.FailureStatusEvent(os.Stdout, "Template download err:"+err.Error())
+			return
+		}
+
+		print.InfoStatusEvent(os.Stdout, "Unpacking template...")
+		unzipcmd := exec.Command("unzip", "-o", tmpDest)
+		unzipcmd.Stderr = os.Stdout
+		unzipcmd.Stdout = os.Stdout
+		fmt.Println(unzipcmd.String())
+		if err := unzipcmd.Run(); err != nil {
+			print.FailureStatusEvent(os.Stdout, "Unzip err:"+err.Error())
+			return
+		}
+
+		if err := os.Rename(defaultUnzippedFilename, targetDir); err != nil {
+			print.FailureStatusEvent(os.Stdout, "Move err:"+err.Error())
+			return
+		}
+
+		print.SuccessStatusEvent(os.Stdout, "Success!! Plugin template created.")
+	},
+}
+
+func init() {
+	Create.Flags().BoolP("help", "h", false, "Print this help message")
+	Create.Flags().BoolVarP(&_gitMode, "git", "", false, "use github")
+	PluginCmd.AddCommand(Create)
+}

--- a/cmd/plugin/create.go
+++ b/cmd/plugin/create.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/tkeel-io/cli/downloadutil"
@@ -65,7 +66,9 @@ tkeel plugin create plugin_name
 		}
 
 		print.InfoStatusEvent(os.Stdout, "Downloading template...")
-
+		if runtime.GOOS == "windows" {
+			_tempDir = "C:\\WINDOWS\\TEMP"
+		}
 		tmpDest := path.Join(_tempDir, downloadedZipFilename)
 		err = downloadutil.Download(tmpDest, zipDownloadURL)
 		if err != nil {

--- a/downloadutil/download.go
+++ b/downloadutil/download.go
@@ -1,0 +1,30 @@
+package downloadutil
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+func Download(filepath string, url string) error {
+	resp, err := http.Get(url) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("http get err:%w", err)
+	}
+	defer resp.Body.Close()
+
+	out, err := os.Create(filepath)
+	if err != nil {
+		return fmt.Errorf("create file err:%w", err)
+	}
+	defer out.Close()
+
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		err = fmt.Errorf("io err:%w", err)
+	}
+
+	return err
+}


### PR DESCRIPTION
support new command to create plugin template.

Implementation logic：
1. download way 
this will download the zip file to `tmp` dir, and use `unzip` command, `unzip` need *Windwos* user installed like what i wrote in README.
  a. download template src zip file 
  b. unzip and rename
2. git command way
**Prerequisites**： installed `git` command 
  a. run git clone repo 
  b. remove this repo .git dir

I tested it on my MacOS , that's work.