### PR TITLE
feat: Optimising repo interceptions

### DIFF
--- a/cmd/plugin/install.go
+++ b/cmd/plugin/install.go
@@ -10,6 +10,8 @@ import (
 	"github.com/tkeel-io/kit/log"
 )
 
+const tkeelChartsRepo = "https://tkeel-io.github.io/helm-charts"
+
 var (
 	debugMode    bool
 	wait         bool
@@ -42,13 +44,15 @@ tkeel plugin remove <pluginID>
 		if sp := strings.Split(pluginFormInput, "@"); len(sp) == 2 {
 			plugin, version = sp[0], sp[1]
 		}
-		urls := strings.Split(plugin, "/")
-		if len(urls) < 2 {
-			print.PendingStatusEvent(os.Stdout, "please input the plugin which you want and the name you want")
-			return
+
+		spi := strings.LastIndex(plugin, "/")
+		repo := tkeelChartsRepo
+		if spi != -1 {
+			repo, plugin = plugin[:spi], plugin[spi+1:]
+			if repo == "" || strings.EqualFold(repo, "tkeel") {
+				repo = tkeelChartsRepo
+			}
 		}
-		repo := strings.Join(urls[:len(urls)-1], "/")
-		plugin = urls[len(urls)-1]
 
 		config := kubernetes.InitConfiguration{
 			Version:   tkeelVersion,

--- a/cmd/plugin/install.go
+++ b/cmd/plugin/install.go
@@ -73,7 +73,7 @@ func init() {
 // parseInstallArg parse the first arg, get repo, plugin and version information.
 // More efficient and concise support for both formats：
 // url style install target plugin: https://tkeel-io.github.io/helm-charts/A@version
-// short style install official plugin： tkeel/B@version or C@version
+// short style install official plugin： tkeel/B@version or C@version.
 func parseInstallArg(arg string) (repo, plugin, version string) {
 	version = "latest"
 	if sp := strings.Split(arg, "@"); len(sp) == 2 {

--- a/cmd/plugin/install.go
+++ b/cmd/plugin/install.go
@@ -76,15 +76,14 @@ func init() {
 // short style install official plugin： tkeel/B@version or C@version.
 func parseInstallArg(arg string) (repo, plugin, version string) {
 	version = "latest"
+	plugin = arg
+
 	if sp := strings.Split(arg, "@"); len(sp) == 2 {
 		plugin, version = sp[0], sp[1]
-	} else {
-		plugin = arg
 	}
 
 	repo = tkeelChartsRepo
-	spi := strings.LastIndex(plugin, "/")
-	if spi != -1 {
+	if spi := strings.LastIndex(plugin, "/"); spi != -1 {
 		repo, plugin = plugin[:spi], plugin[spi+1:]
 		if repo == "" || strings.EqualFold(repo, "tkeel") {
 			repo = tkeelChartsRepo

--- a/cmd/plugin/install.go
+++ b/cmd/plugin/install.go
@@ -38,21 +38,9 @@ tkeel plugin remove <pluginID>
 			print.PendingStatusEvent(os.Stdout, "please input the plugin which you want and the name you want")
 			return
 		}
-		pluginFormInput, name := args[0], args[1]
-		plugin := pluginFormInput
-		version := "latest"
-		if sp := strings.Split(pluginFormInput, "@"); len(sp) == 2 {
-			plugin, version = sp[0], sp[1]
-		}
 
-		spi := strings.LastIndex(plugin, "/")
-		repo := tkeelChartsRepo
-		if spi != -1 {
-			repo, plugin = plugin[:spi], plugin[spi+1:]
-			if repo == "" || strings.EqualFold(repo, "tkeel") {
-				repo = tkeelChartsRepo
-			}
-		}
+		name := args[1]
+		repo, plugin, version := parseInstallArg(args[0])
 
 		config := kubernetes.InitConfiguration{
 			Version:   tkeelVersion,
@@ -80,4 +68,28 @@ func init() {
 	PluginInstallCmd.Flags().StringVarP(&tkeelVersion, "tkeel_version", "", "0.2.0", "The plugin depened tkeel version.")
 	PluginInstallCmd.Flags().BoolP("help", "h", false, "Print this help message")
 	PluginCmd.AddCommand(PluginInstallCmd)
+}
+
+// parseInstallArg parse the first arg, get repo, plugin and version information.
+// More efficient and concise support for both formats：
+// url style install target plugin: https://tkeel-io.github.io/helm-charts/A@version
+// short style install official plugin： tkeel/B@version or C@version
+func parseInstallArg(arg string) (repo, plugin, version string) {
+	version = "latest"
+	if sp := strings.Split(arg, "@"); len(sp) == 2 {
+		plugin, version = sp[0], sp[1]
+	} else {
+		plugin = arg
+	}
+
+	repo = tkeelChartsRepo
+	spi := strings.LastIndex(plugin, "/")
+	if spi != -1 {
+		repo, plugin = plugin[:spi], plugin[spi+1:]
+		if repo == "" || strings.EqualFold(repo, "tkeel") {
+			repo = tkeelChartsRepo
+			return
+		}
+	}
+	return
 }

--- a/cmd/plugin/install_test.go
+++ b/cmd/plugin/install_test.go
@@ -1,0 +1,30 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseInstallArg(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  struct {
+			repo, plugin, version string
+		}
+	}{
+		{"url test", "http://github.com/install/pluginname", struct{ repo, plugin, version string }{"http://github.com/install", "pluginname", "latest"}},
+		{"short test", "tkeel/pluginname@v0.2.0", struct{ repo, plugin, version string }{tkeelChartsRepo, "pluginname", "v0.2.0"}},
+		{"short test no repo", "pluginname", struct{ repo, plugin, version string }{repo: tkeelChartsRepo, plugin: "pluginname", version: "latest"}},
+		{"invalid test", "test/plugin", struct{ repo, plugin, version string }{repo: "test", plugin: "plugin", version: "latest"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			repo, plugin, version := parseInstallArg(test.input)
+			assert.Equal(t, repo, test.want.repo)
+			assert.Equal(t, plugin, test.want.plugin)
+			assert.Equal(t, version, test.want.version)
+		})
+	}
+}


### PR DESCRIPTION
Optimising repo interceptions

and make install support default repo named tkeel, like below:
```bash
# Old style also supported
$ tkeel plugin install https://tkeel-io.github.io/helm-charts/iothub@v0.2.0 iothub

# named repo tkeel or TKEEL whaterver
$ tkeel plugin install tkeel/iothub iothub
$ tkeel plugin install tkeel/iothub@v0.2.0 iothub

# no repo and use default official repo
$ tkeel plugin install iothub iothub
$ tkeel plugin install iothub@v0.2.0 iothub

```